### PR TITLE
Update ClickHouseStatement.php

### DIFF
--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -245,6 +245,8 @@ class ClickHouseStatement implements \IteratorAggregate, Statement
     {
         $this->values[$param] = $value;
         $this->types[$param]  = $type;
+        
+        return true;
     }
 
     /**
@@ -254,6 +256,8 @@ class ClickHouseStatement implements \IteratorAggregate, Statement
     {
         $this->values[$column] = &$variable;
         $this->types[$column]  = $type;
+        
+        return true;
     }
 
     public function errorCode() : void


### PR DESCRIPTION
on a php8 + `sentry/sentry-symfony` installed i got the error

```
Sentry\SentryBundle\Tracing\Doctrine\DBAL\TracingStatementForV2::bindValue(): Return value must be of type bool, null returned
```

so, this is a small fix to make `bindValue` and `bindParam` methods compatible with the parent class method declarations

